### PR TITLE
Adding in Redis backend support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, W503, W504
+ignore = E203, E266, E704, W503, W504
 max-line-length = 88
 max-complexity = 12
 select = C,E,F,W,B,B9

--- a/README.md
+++ b/README.md
@@ -13,33 +13,51 @@ A flexible and user-friendly Python caching utility that provides a **unified in
 
 ---
 
-## Installation
+## Supported Backends
 
-You can install `cacheio` via pip. It supports optional dependency groups for backend support.
+`cacheio` supports multiple caching backends, providing both synchronous and asynchronous caching through well-established libraries:
 
-### Basic Installation
+### Synchronous Backends (via `cachelib`)
 
-Install core library without caching backends:
+- **In-Memory Cache**  
+  Backed by [`cachelib.SimpleCache`](https://github.com/pallets/cachelib)  
+  Created with: `CacheFactory.memory_cache()`  
+  Suitable for lightweight, local caching with configurable TTL and item thresholds.
 
-```bash
-pip install cacheio
-```
+- **Redis Cache**  
+  Backed by [`cachelib.RedisCache`](https://github.com/pallets/cachelib)  
+  Created with: `CacheFactory.redis_cache(host=..., port=..., ...)`  
+  Suitable for distributed caching with Redis, supporting connection parameters, TTL, and key namespaces.
 
-### Installing with Backends
+> **Note:** The synchronous backends require installing the `[sync]` extras:  
+> ```bash
+> pip install "cacheio[sync]"
+> ```
 
-- **Synchronous caching (cachelib-based):**
+---
 
-```bash
-pip install "cacheio[sync]"
-```
+### Asynchronous Backends (via `aiocache`)
 
-- **Asynchronous caching (aiocache-based):**
+- **In-Memory Async Cache**  
+  Backed by [`aiocache.Cache`](https://github.com/aio-libs/aiocache) with the `MEMORY` backend  
+  Created with: `CacheFactory.async_memory_cache()`  
+  Useful for async applications needing lightweight local caching.
 
-```bash
-pip install "cacheio[async]"
-```
+- **Redis Async Cache**  
+  Backed by [`aiocache.RedisCache`](https://github.com/aio-libs/aiocache)  
+  Created with: `CacheFactory.async_redis_cache(host=..., port=..., ...)`  
+  Supports Redis with async operations, configurable connection options, TTL, and dynamic namespace prefixes (including callables).
 
-- **Full installation (both sync and async):**
+> **Note:** The asynchronous backends require installing the `[async]` extras:  
+> ```bash
+> pip install "cacheio[async]"
+> ```
+
+---
+
+### Full Installation
+
+For both synchronous and asynchronous caching support:
 
 ```bash
 pip install "cacheio[full]"

--- a/cacheio/_cache_factory.py
+++ b/cacheio/_cache_factory.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 try:
-    from cachelib import SimpleCache as Cache
+    from cachelib import SimpleCache as SyncCache, RedisCache as SyncRedisCache
+
+    CACHELIB_LOADED = True
 except ImportError:
-    Cache = None
+    CACHELIB_LOADED = False
+    SyncCache = None
+    SyncRedisCache = None
 
 try:
     from aiocache import Cache as AsyncCache
+
+    AIOCACHE_LOADED = True
 except ImportError:
+    AIOCACHE_LOADED = False
     AsyncCache = None
 
 from ._config import config
@@ -17,42 +24,130 @@ from ._async_adapter import AsyncAdapter
 from ._adapter import Adapter
 
 
+def ensure_cachelib() -> None:
+    """
+    Raise ImportError if `cachelib` is not installed.
+
+    This helper function ensures that the synchronous caching
+    dependencies are available before attempting to use them.
+
+    :raises ImportError: If `cachelib` is not installed.
+    """
+    if not CACHELIB_LOADED:
+        raise ImportError(
+            "The 'cachelib' library is not installed. Please install "
+            "'cacheio[sync]' to use synchronous caching."
+        )
+
+
+def ensure_aiocache() -> None:
+    """
+    Raise ImportError if `aiocache` is not installed.
+
+    This helper function ensures that the asynchronous caching
+    dependencies are available before attempting to use them.
+
+    :raises ImportError: If `aiocache` is not installed.
+    """
+    if not AIOCACHE_LOADED:
+        raise ImportError(
+            "The 'aiocache' library is not installed. Please install "
+            "'cacheio[async]' to use asynchronous caching."
+        )
+
+
 class CacheFactory:
     """
-    A factory class for building synchronous and asynchronous cache adapters.
+    Factory class for creating synchronous and asynchronous cache adapters.
+
+    Provides static methods to create configured cache instances
+    backed by either memory or Redis, using `cachelib` and `aiocache`.
     """
 
     @staticmethod
     def memory_cache(
         *,
         ttl: int | None = None,
-        threshold: int = 500,
+        threshold: int | None = None,
     ) -> Adapter:
         """
-        Builds a synchronous `CacheAdapter` instance using an in-memory backend.
+        Create a synchronous in-memory cache Adapter.
 
-        This method creates a `cachelib.SimpleCache` with the specified
-        parameters and wraps it in a `CacheAdapter`. The TTL defaults
-        to a value from the `config.default_ttl`.
+        Constructs a `cachelib.SimpleCache` instance with the specified
+        parameters, wrapped in an `Adapter`.
+        The `ttl` and `threshold` parameters default to global values
+        from `config` if not provided.
 
-        :param ttl: The time-to-live for cache entries in seconds.
+        :param ttl: Time-to-live for cache entries in seconds.
+                    If None, defaults to `config.default_ttl`.
         :type ttl: int | None
-        :param threshold: The maximum number of items the cache stores before it
-                          starts deleting some.
-        :type threshold: int
-        :return: A configured `CacheAdapter` instance.
-        :rtype: CacheAdapter
+        :param threshold: Maximum number of items before cache pruning.
+                          If None, defaults to `config.default_threshold`.
+        :type threshold: int | None
+        :return: A configured synchronous cache Adapter instance.
+        :rtype: Adapter
         """
-        if Cache is None:
-            raise ImportError(
-                "The 'cachelib' library is not installed. Please install "
-                "'cacheio[sync]' to use synchronous caching."
+        ensure_cachelib()
+
+        ttl = config.get("default_ttl", ttl)
+        threshold = config.get("default_threshold", threshold)
+
+        return Adapter(SyncCache(threshold, ttl))
+
+    @staticmethod
+    def redis_cache(
+        *,
+        ttl: int | None = None,
+        host: Any = "localhost",
+        port: int = 6379,
+        password: str | None = None,
+        db: int = 0,
+        namespace: str | Callable[[], str] | None = None,
+        **kwargs: Any,
+    ) -> Adapter:
+        """
+        Create a synchronous Redis cache Adapter.
+
+        Constructs a `cachelib.RedisCache` instance with the provided
+        parameters, wrapped in an `Adapter`. The `ttl` parameter defaults
+        to the global value from `config` if not provided.
+
+        :param ttl: Time-to-live for cache entries in seconds.
+                    This value is mapped to `default_timeout` for the `cachelib`
+                    backend. If None, defaults to `config.default_ttl`.
+        :type ttl: int | None
+        :param host: Redis server hostname or IP. Defaults to "localhost".
+        :type host: Any
+        :param port: Redis server port. Defaults to 6379.
+        :type port: int
+        :param password: Password for Redis authentication.
+        :type password: str | None
+        :param db: Redis database index. Defaults to 0.
+        :type db: int
+        :param namespace: Cache key prefix as string or callable returning a string.
+                          This value is mapped to `key_prefix` for the `cachelib`
+                          backend. If callable, it is not invoked automatically here.
+        :type namespace: str | Callable[[], str] | None
+        :param kwargs: Additional keyword arguments forwarded to `redis.Redis`.
+        :type kwargs: Any
+        :return: A configured synchronous Redis cache Adapter instance.
+        :rtype: Adapter
+        """
+        ensure_cachelib()
+
+        ttl = config.get("default_ttl", ttl)
+
+        return Adapter(
+            SyncRedisCache(
+                host=host,
+                port=port,
+                password=password,
+                db=db,
+                default_timeout=ttl,
+                key_prefix=namespace,
+                **kwargs,
             )
-
-        ttl = int(ttl or config.default_ttl)
-        threshold = int(threshold or config.default_threshold)
-
-        return Adapter(Cache(threshold, ttl))
+        )
 
     @staticmethod
     def async_memory_cache(
@@ -61,27 +156,88 @@ class CacheFactory:
         **kwargs: Any,
     ) -> AsyncAdapter:
         """
-        Builds an asynchronous `AsyncCacheAdapter` instance using an in-memory backend.
+        Create an asynchronous in-memory cache AsyncAdapter.
 
-        This method creates an `aiocache.Cache` instance with an in-memory
-        backend and wraps it in an `AsyncCacheAdapter`. The TTL defaults
-        to a value from the `config.default_ttl`.
+        Constructs an `aiocache.Cache` instance using the in-memory
+        backend, wrapped in an `AsyncAdapter`.
+        The `ttl` parameter defaults to the global value from `config`
+        if not provided.
 
-        :param ttl: The time-to-live for cache entries in seconds.
+        :param ttl: Time-to-live for cache entries in seconds.
+                    If None, defaults to `config.default_ttl`.
         :type ttl: int | None
-        :param kwargs: Additional keyword arguments to pass to the cache constructor.
+        :param kwargs: Additional keyword arguments forwarded to `aiocache.Cache`.
         :type kwargs: Any
-        :return: A configured `AsyncCacheAdapter` instance.
-        :rtype: AsyncCacheAdapter
+        :return: A configured asynchronous in-memory cache AsyncAdapter instance.
+        :rtype: AsyncAdapter
         """
-        if AsyncCache is None:
-            raise ImportError(
-                "The 'aiocache' library is not installed. Please install "
-                "'cacheio[async]' to use asynchronous caching."
-            )
+        ensure_aiocache()
 
-        ttl = int(ttl or config.default_ttl)
+        ttl = config.get("default_ttl", ttl)
+
         return AsyncAdapter(AsyncCache(AsyncCache.MEMORY, ttl=ttl, **kwargs))
+
+    @staticmethod
+    def async_redis_cache(
+        *,
+        ttl: int | None = None,
+        host: Any = "localhost",
+        port: int = 6379,
+        password: str | None = None,
+        db: int = 0,
+        namespace: str | Callable[[], str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncAdapter:
+        """
+        Create an asynchronous Redis cache AsyncAdapter.
+
+        Constructs an `aiocache.RedisCache` instance with the specified
+        parameters, wrapped in an `AsyncAdapter`. The `ttl` parameter defaults
+        to the global value from `config` if not provided.
+
+        If `namespace` is a callable, it is invoked before being passed
+        to the cache backend.
+
+        :param ttl: Time-to-live for cache entries in seconds.
+                    This value is mapped to `timeout` for the `aiocache` backend.
+                    If None, defaults to `config.default_ttl`.
+        :type ttl: int | None
+        :param host: Redis server hostname or IP. This value is mapped to `endpoint`
+                     for the `aiocache` backend. Defaults to "localhost".
+        :type host: Any
+        :param port: Redis server port. Defaults to 6379.
+        :type port: int
+        :param password: Password for Redis authentication.
+        :type password: str | None
+        :param db: Redis database index. Defaults to 0.
+        :type db: int
+        :param namespace: Cache key prefix as string or callable returning a string.
+                          If callable, it is invoked to get the prefix.
+        :type namespace: str | Callable[[], str] | None
+        :param kwargs: Additional keyword arguments forwarded to `aiocache.RedisCache`.
+        :type kwargs: Any
+        :return: A configured asynchronous Redis cache AsyncAdapter instance.
+        :rtype: AsyncAdapter
+        """
+        ensure_aiocache()
+
+        ttl = config.get("default_ttl", ttl)
+
+        if callable(namespace):
+            namespace = namespace()
+
+        return AsyncAdapter(
+            AsyncCache(
+                AsyncCache.REDIS,
+                endpoint=host,
+                port=port,
+                password=password,
+                db=db,
+                timeout=ttl,
+                namespace=namespace,
+                **kwargs,
+            )
+        )
 
 
 __all__ = ("CacheFactory",)

--- a/cacheio/_config.py
+++ b/cacheio/_config.py
@@ -7,15 +7,21 @@ This module allows users to modify default settings, such as the time-to-live
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Literal, TypeVar, cast, overload
+
+
+T = TypeVar("T")
+IntLiteral = Literal["default_ttl", "default_threshold"]
 
 
 class Config:
     """A simple configuration object to store global settings for the caching library.
 
-    :ivar default_ttl: The default time-to-live in seconds for cache
-                       entries if no specific TTL is provided.
+    :ivar default_ttl: The default time-to-live in seconds for cache entries if no
+                       specific TTL is provided.
     :vartype default_ttl: int
+    :ivar default_threshold: The default entries threshold the cache backend holds.
+    :vartype default_threshold: int
     """
 
     __slots__ = (
@@ -23,9 +29,36 @@ class Config:
         "default_threshold",
     )
 
-    def __init__(self):
-        self.default_ttl = 300
-        self.default_threshold = 500
+    def __init__(self) -> None:
+        self.default_ttl: int = 300
+        self.default_threshold: int = 500
+
+    @overload
+    def get(self, attr: IntLiteral, override: int | None = None) -> int: ...
+
+    @overload
+    def get(self, attr: str, override: T | None = None) -> T: ...
+
+    def get(self, attr: str, override: T | None = None) -> T:
+        """
+        Retrieve a configuration attribute value.
+
+        :param attr: The name of the attribute to retrieve.
+        :type attr: str
+        :param override: The default value to return if the attribute does not exist.
+        :type override: T
+        :return: The attribute value or the provided default.
+        :rtype: T
+        :raises AttributeError: If the attribute does not exist
+        """
+        if not hasattr(self, attr):
+            raise AttributeError(f"Unknown configuration attribute: '{attr}'")
+
+        if override is not None:
+            return cast(T, override)
+
+        value = getattr(self, attr)
+        return cast(T, value)
 
 
 config = Config()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ exclude = '''
 '''
 
 [tool.flake8]
-ignore = ["E203", "E266", "W503", "W504"]
+ignore = ["E203", "E266", "E704", "W503", "W504"]
 max-line-length = 88
 max-complexity = 12
 select = ["C", "E", "F", "W", "B", "B9"]

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -7,85 +7,127 @@ import pytest
 from cacheio import config, CacheFactory, Adapter, AsyncAdapter
 
 CACHE = "cacheio._cache_factory.SyncCache"
+REDIS_CACHE = "cacheio._cache_factory.SyncRedisCache"
 ASYNC_CACHE = "cacheio._cache_factory.AsyncCache"
 
 
 class TestCacheFactory:
     """Test suite for the CacheFactory class."""
 
-    def test_memory_cache_creates_adapter_with_default_ttl(self):
+    def test_memory_cache_creates_adapter_with_default_ttl_and_threshold(self):
         """
-        Tests that memory_cache creates a synchronous Adapter with the default TTL
-        from the global config.
+        Tests memory_cache creates Adapter with default TTL and threshold from config.
         """
         with patch(CACHE) as mock_cache_class:
             config.default_ttl = 300
+            config.default_threshold = 500
             adapter = CacheFactory.memory_cache()
 
             assert isinstance(adapter, Adapter)
-
-            mock_cache_class.assert_called_once_with(500, config.default_ttl)
+            mock_cache_class.assert_called_once_with(500, 300)
 
     def test_memory_cache_creates_adapter_with_custom_ttl(self):
         """
-        Tests that memory_cache uses a provided custom TTL.
+        Tests memory_cache uses provided custom TTL.
         """
         with patch(CACHE) as mock_cache_class:
+            config.default_threshold = 500
             custom_ttl = 600
             adapter = CacheFactory.memory_cache(ttl=custom_ttl)
 
             assert isinstance(adapter, Adapter)
-
             mock_cache_class.assert_called_once_with(500, custom_ttl)
 
     def test_memory_cache_creates_adapter_with_custom_threshold(self):
         """
-        Tests that memory_cache uses a provided custom threshold.
+        Tests memory_cache uses provided custom threshold.
         """
         with patch(CACHE) as mock_cache_class:
+            config.default_ttl = 300
             custom_threshold = 1000
             adapter = CacheFactory.memory_cache(threshold=custom_threshold)
 
             assert isinstance(adapter, Adapter)
+            mock_cache_class.assert_called_once_with(custom_threshold, 300)
 
-            mock_cache_class.assert_called_once_with(
-                custom_threshold, config.default_ttl
-            )
-
-    def test_memory_cache_raises_importerror_if_cachelib_is_not_installed(self):
+    def test_memory_cache_raises_importerror_if_cachelib_not_installed(self):
         """
-        Tests that memory_cache raises ImportError if cachelib is missing.
+        Tests memory_cache raises ImportError if cachelib not loaded.
         """
         with patch("cacheio._cache_factory.CACHELIB_LOADED", False), patch(CACHE, None):
             with pytest.raises(
-                ImportError, match="The 'cachelib' library is not installed."
+                ImportError,
+                match="The 'cachelib' library is not installed.",
             ):
                 CacheFactory.memory_cache()
+
+    def test_redis_cache_creates_adapter_with_defaults(self):
+        """
+        Tests redis_cache creates Adapter with default params from config.
+        """
+        with patch(REDIS_CACHE) as mock_redis_cache_class:
+            config.default_ttl = 300
+            adapter = CacheFactory.redis_cache()
+
+            assert isinstance(adapter, Adapter)
+            mock_redis_cache_class.assert_called_once_with(
+                host="localhost",
+                port=6379,
+                password=None,
+                db=0,
+                default_timeout=300,
+                key_prefix=None,
+            )
+
+    def test_redis_cache_creates_adapter_with_custom_params(self):
+        """
+        Tests redis_cache creates Adapter with custom parameters.
+        """
+        with patch(REDIS_CACHE) as mock_redis_cache_class:
+            adapter = CacheFactory.redis_cache(
+                ttl=900,
+                host="redis.local",
+                port=6380,
+                password="secret",
+                db=2,
+                namespace="prefix",
+                extra_arg="foo",
+            )
+
+            assert isinstance(adapter, Adapter)
+            mock_redis_cache_class.assert_called_once_with(
+                host="redis.local",
+                port=6380,
+                password="secret",
+                db=2,
+                default_timeout=900,
+                key_prefix="prefix",
+                extra_arg="foo",
+            )
 
     @pytest.mark.asyncio
     async def test_async_memory_cache_creates_async_adapter_with_default_ttl(self):
         """
-        Tests that async_memory_cache creates an asynchronous Adapter with the default
-        TTL from the global config.
+        Tests async_memory_cache creates AsyncAdapter with default TTL from config.
         """
         with patch(ASYNC_CACHE) as mock_async_cache_class:
             config.default_ttl = 300
             adapter = CacheFactory.async_memory_cache()
 
             assert isinstance(adapter, AsyncAdapter)
-
             mock_async_cache_class.assert_called_once_with(
-                mock_async_cache_class.MEMORY, ttl=config.default_ttl
+                mock_async_cache_class.MEMORY, ttl=300
             )
 
     @pytest.mark.asyncio
     async def test_async_memory_cache_creates_async_adapter_with_custom_ttl(self):
         """
-        Tests that async_memory_cache uses a provided custom TTL.
+        Tests async_memory_cache uses provided custom TTL.
         """
         with patch(ASYNC_CACHE) as mock_async_cache_class:
             custom_ttl = 900
             adapter = CacheFactory.async_memory_cache(ttl=custom_ttl)
+
             assert isinstance(adapter, AsyncAdapter)
             mock_async_cache_class.assert_called_once_with(
                 mock_async_cache_class.MEMORY, ttl=custom_ttl
@@ -94,8 +136,7 @@ class TestCacheFactory:
     @pytest.mark.asyncio
     async def test_async_memory_cache_creates_adapter_with_custom_kwargs(self):
         """
-        Tests that async_memory_cache forwards custom keyword arguments to the
-        aiocache constructor.
+        Tests async_memory_cache forwards custom kwargs to aiocache.Cache.
         """
         with patch(ASYNC_CACHE) as mock_async_cache_class:
             config.default_ttl = 300
@@ -103,22 +144,91 @@ class TestCacheFactory:
             adapter = CacheFactory.async_memory_cache(**custom_kwargs)
 
             assert isinstance(adapter, AsyncAdapter)
-
             mock_async_cache_class.assert_called_once_with(
-                mock_async_cache_class.MEMORY, ttl=config.default_ttl, **custom_kwargs
+                mock_async_cache_class.MEMORY, ttl=300, **custom_kwargs
             )
 
     @pytest.mark.asyncio
-    async def test_async_memory_cache_raises_importerror_if_aiocache_is_not_installed(
+    async def test_async_memory_cache_raises_importerror_if_aiocache_not_installed(
         self,
     ):
         """
-        Tests that async_memory_cache raises ImportError if aiocache is missing.
+        Tests async_memory_cache raises ImportError if aiocache not loaded.
         """
         with patch("cacheio._cache_factory.AIOCACHE_LOADED", False), patch(
             ASYNC_CACHE, None
         ):
             with pytest.raises(
-                ImportError, match="The 'aiocache' library is not installed."
+                ImportError,
+                match="The 'aiocache' library is not installed.",
             ):
                 CacheFactory.async_memory_cache()
+
+    @pytest.mark.asyncio
+    async def test_async_redis_cache_creates_adapter_with_defaults(self):
+        """
+        Tests async_redis_cache creates AsyncAdapter with default params from config.
+        """
+        with patch(ASYNC_CACHE) as mock_async_cache_class:
+            config.default_ttl = 300
+            adapter = CacheFactory.async_redis_cache()
+
+            assert isinstance(adapter, AsyncAdapter)
+            mock_async_cache_class.assert_called_once_with(
+                mock_async_cache_class.REDIS,
+                endpoint="localhost",
+                port=6379,
+                password=None,
+                db=0,
+                timeout=300,
+                namespace=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_redis_cache_creates_adapter_with_custom_params(self):
+        """
+        Tests async_redis_cache creates AsyncAdapter with custom parameters including
+        callable namespace.
+        """
+        with patch(ASYNC_CACHE) as mock_async_cache_class:
+            # Namespace as string
+            adapter = CacheFactory.async_redis_cache(
+                ttl=900,
+                host="redis.local",
+                port=6380,
+                password="secret",
+                db=2,
+                namespace="prefix",
+                extra_arg="foo",
+            )
+            assert isinstance(adapter, AsyncAdapter)
+            mock_async_cache_class.assert_called_with(
+                mock_async_cache_class.REDIS,
+                endpoint="redis.local",
+                port=6380,
+                password="secret",
+                db=2,
+                timeout=900,
+                namespace="prefix",
+                extra_arg="foo",
+            )
+
+            # Namespace as callable
+            mock_async_cache_class.reset_mock()
+
+            def namespace_callable():
+                return "callable_prefix"
+
+            adapter = CacheFactory.async_redis_cache(
+                namespace=namespace_callable,
+            )
+            assert isinstance(adapter, AsyncAdapter)
+            mock_async_cache_class.assert_called_with(
+                mock_async_cache_class.REDIS,
+                endpoint="localhost",
+                port=6379,
+                password=None,
+                db=0,
+                timeout=300,
+                namespace="callable_prefix",
+            )

--- a/tests/test_cache_factory.py
+++ b/tests/test_cache_factory.py
@@ -6,7 +6,7 @@ import pytest
 
 from cacheio import config, CacheFactory, Adapter, AsyncAdapter
 
-CACHE = "cacheio._cache_factory.Cache"
+CACHE = "cacheio._cache_factory.SyncCache"
 ASYNC_CACHE = "cacheio._cache_factory.AsyncCache"
 
 
@@ -56,7 +56,7 @@ class TestCacheFactory:
         """
         Tests that memory_cache raises ImportError if cachelib is missing.
         """
-        with patch(CACHE, None):
+        with patch("cacheio._cache_factory.CACHELIB_LOADED", False), patch(CACHE, None):
             with pytest.raises(
                 ImportError, match="The 'cachelib' library is not installed."
             ):
@@ -115,7 +115,9 @@ class TestCacheFactory:
         """
         Tests that async_memory_cache raises ImportError if aiocache is missing.
         """
-        with patch(ASYNC_CACHE, None):
+        with patch("cacheio._cache_factory.AIOCACHE_LOADED", False), patch(
+            ASYNC_CACHE, None
+        ):
             with pytest.raises(
                 ImportError, match="The 'aiocache' library is not installed."
             ):

--- a/tests/test_cache_factory_imports.py
+++ b/tests/test_cache_factory_imports.py
@@ -8,7 +8,7 @@ def test_cachelib_import_failure():
 
     with patch.dict("sys.modules", {"cachelib": None}):
         reloaded_module = importlib.reload(importlib.import_module(module_to_test))
-        assert reloaded_module.Cache is None
+        assert reloaded_module.SyncCache is None
 
 
 def test_aiocache_import_failure():


### PR DESCRIPTION
This adds in `cachelib.RedisCache` and `aiocache.Cache.REDIS` support in `CacheFactory`.

- `CacheFactory.redis_cache(...)`
- `CacheFactory.async_redis_cache(...)`